### PR TITLE
Fixed wrong resolving of custom steamid with a '-' char

### DIFF
--- a/src/SteamAPI.js
+++ b/src/SteamAPI.js
@@ -18,7 +18,7 @@ const reID = /^\d{17}$/;
 
 const reProfileBase = String.raw`(?:(?:(?:(?:https?)?:\/\/)?(?:www\.)?steamcommunity\.com)?)?\/?`;
 const reProfileURL = RegExp(String.raw`${reProfileBase}(?:profiles\/)?(\d{17})`, 'i');
-const reProfileID = RegExp(String.raw`${reProfileBase}(?:id\/)?(\w{2,32})`, 'i');
+const reProfileID = RegExp(String.raw`${reProfileBase}(?:id\/)?([a-zA-Z0-9_-]{2,32})`, 'i');
 
 const STATUS_SUCCESS = 1;
 


### PR DESCRIPTION
You can test your current code with this custom profile url for example: https://steamcommunity.com/id/-koby-
With the current code it is wrongly resolved to: 76561197991350313
This is due to the id being seen as this:  https://steamcommunity.com/id/id
With the fix it is correctly resolved to: 76561198111012432