### PR TITLE
Throw appropriate error in `getUserOwnedGames` when the user's game details are private

### DIFF
--- a/src/SteamAPI.js
+++ b/src/SteamAPI.js
@@ -327,7 +327,7 @@ class SteamAPI {
 
 		return this
 			.get(`/IPlayerService/GetOwnedGames/v1?steamid=${id}&include_appinfo=1`)
-			.then(json => json.response.games.map(game => new Game(game)));
+			.then(json => json.response.games ? json.response.games.map(game => new Game(game)) : Promise.reject(new Error('No games found')));
 	}
 
 	/**


### PR DESCRIPTION
When the game details of a user are not private, the response looks like this:
```json
{
  "response": {
    "game_count": 1,
    "games": [
      {
        "appid": 220,
        "playtime_forever": 125,
        "playtime_windows_forever": 0,
        "playtime_mac_forever": 0,
        "playtime_linux_forever": 0
      }
    ]
  }
}
```

When the game details are private, however, the response looks like this:
```json
{"response":{}}
```

In both cases, the HTTP status code is 200. That's why currently, you get this error when the profile is private: `TypeError: Cannot read property 'map' of undefined`. This PR throws a `No games found` error instead.
