### PR TITLE
feat(getGameDetails): adding support for translated description

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ steam.getUserSummary('76561198146931523').then(summary => {
     * [.getFeaturedCategories()](#SteamAPI+getFeaturedCategories) ⇒ <code>Promise.&lt;Array.&lt;Object&gt;&gt;</code>
     * [.getFeaturedGames()](#SteamAPI+getFeaturedGames) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.getGameAchievements(app)](#SteamAPI+getGameAchievements) ⇒ <code>Promise.&lt;Object&gt;</code>
-    * [.getGameDetails(app, [force], [region])](#SteamAPI+getGameDetails) ⇒ <code>Promise.&lt;Object&gt;</code>
+    * [.getGameDetails(app, [force], [region], [language])](#SteamAPI+getGameDetails) ⇒ <code>Promise.&lt;Object&gt;</code>
     * [.getGameNews(app)](#SteamAPI+getGameNews) ⇒ <code>Promise.&lt;Array.&lt;Object&gt;&gt;</code>
     * [.getGamePlayers(app)](#SteamAPI+getGamePlayers) ⇒ <code>Promise.&lt;number&gt;</code>
     * [.getGameSchema(app)](#SteamAPI+getGameSchema) ⇒ <code>Promise.&lt;Object&gt;</code>
@@ -162,7 +162,7 @@ Get achievements for app id.
 
 <a name="SteamAPI+getGameDetails"></a>
 
-### steamAPI.getGameDetails(app, [force], [region]) ⇒ <code>Promise.&lt;Object&gt;</code>
+### steamAPI.getGameDetails(app, [force], [region], [language]) ⇒ <code>Promise.&lt;Object&gt;</code>
 Get details for app id.
 <warn>Requests for this endpoint are limited to 200 every 5 minutes</warn>
 
@@ -173,7 +173,11 @@ Get details for app id.
 | --- | --- | --- | --- |
 | app | <code>string</code> |  | App ID |
 | [force] | <code>boolean</code> | <code>false</code> | Overwrite cache |
-| [region] | <code>string</code> | <code>&quot;us&quot;</code> | Store region |
+| [region] | <code>string</code> | <code>&quot;us&quot;</code> | Currency region |
+| [language] | <code>string</code> | <code>&quot;english&quot;</code> | Description language |
+
+**Warning** not every `language` is supported. A list of available languages can be found [here](https://www.ibabbleon.com/Steam-Supported-Languages-API-Codes.html).
+Those are also used to filter your passed argument.
 
 <a name="SteamAPI+getGameNews"></a>
 

--- a/src/SteamAPI.js
+++ b/src/SteamAPI.js
@@ -14,7 +14,8 @@ const Game = require('./structures/Game');
 const objectify = require('./utils/objectify');
 const fetch = require('./utils/fetch');
 const { version, name } = require('../package.json');
-const regions = ['us', 'ca', 'cc', 'es', 'de', 'fr', 'ru', 'nz', 'au', 'uk'];
+const allowedRegions = ['us', 'ca', 'cc', 'es', 'de', 'fr', 'ru', 'nz', 'au', 'uk'];
+const allowedLanguages = ['arabic', 'bulgarian', 'schinese', 'tchinese', 'czech', 'danish', 'dutch', 'english', 'finnish', 'french', 'german', 'greek', 'hungarian', 'italian', 'japanese', 'koreana', 'norwegian', 'polish', 'brazilian', 'portuguese', 'romanian', 'russian', 'latam', 'spanish', 'swedish', 'thai', 'turkish', 'ukrainian', 'vietnamese'];
 const reApp = /^\d{1,7}$/;
 const reID = /^\d{17}$/;
 
@@ -173,19 +174,22 @@ class SteamAPI {
 	 * <warn>Requests for this endpoint are limited to 200 every 5 minutes</warn>
 	 * @param {string} app App ID
 	 * @param {boolean} [force=false] Overwrite cache
-	 * @param {string} [region=us] Store region
+	 * @param {string} [region=us] Currency region
+	 * @param {string} [language=english] Description language
 	 * @returns {Promise<Object>} App details for ID
 	 */
-	getGameDetails(app, force = false, region = 'us') {
+	getGameDetails(app, force = false, region = 'us', language = 'english') {
 		if (!reApp.test(app)) return Promise.reject(TypeError('Invalid/no app provided'));
-		if (!regions.includes(region)) return Promise.reject(TypeError('Invalid region provided'));
+		if (!allowedRegions.includes(region)) return Promise.reject(TypeError('Invalid region provided'));
+		if (!allowedLanguages.includes(language)) return Promise.reject(TypeError('Invalid language provided'));
 
 		const request = () => this
-			.get(`/appdetails?appids=${app}&cc=${region}`, this.baseStore)
+			.get(`/appdetails?appids=${app}&cc=${region}&l=${language}`, this.baseStore)
 			.then(json => json[app].success
 				? json[app].data
 				: Promise.reject(new Error('No app found')),
 			);
+
 		const key = `${app}-${region.toLowerCase()}`;
 
 		if (!force && this.options.enabled && this.cache.has(key) && this.cache.get(key)[0] > Date.now())

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,8 @@ steam.resolve('id/DimGG/').then(async id => {
 	await steam.getGameDetails(730).then(inspect);
 	console.log('getGameDetails of another region');
 	await steam.getGameDetails(730, false, 'es').then(inspect);
+	console.log('getGameDetails of another region in another language');
+	await steam.getGameDetails(730, false, 'es', 'russian').then(inspect);
 	console.log('getGameNews');
 	await steam.getGameNews(730).then(inspect);
 	console.log('getGamePlayers');


### PR DESCRIPTION
Adding support for translated fields:

- detailed_description
- about_the_game
- short_description
- supported_languages
- pc_requirements
- mac_requirements
- linux_requirements
- package_groups.title
- package_groups.selection_text
- package_groups.subs.option_text
- categories.description
- genres.description
- achievements.highlighted.name
- content_descriptors.notes

I don't know which languages are supported by Steam, so I did not add any limit.
I found this ["source"](https://www.ibabbleon.com/Steam-Supported-Languages-API-Codes.html), but I don't know if it is legit.

If a game does not have a translation for a requested language, Steam will use English.

Based on: https://wiki.teamfortress.com/wiki/User:RJackson/StorefrontAPI#Global_parameters

This will require an update of the TypeScript types: https://www.npmjs.com/package/@types/steamapi
(I don't know how exactly.)

---

As the parameter `region` was not that descriptive, I did rename its hint.