### PR TITLE
fix: Address edge case with user achievements missing

### DIFF
--- a/src/structures/UserAchievements.ts
+++ b/src/structures/UserAchievements.ts
@@ -12,6 +12,6 @@ export default class UserAchievements extends User {
 		super(data);
 
 		this.game = data.gameName;
-		this.achievements = data.achievements.map((achievement: any) => new UserAchievement(achievement));
+		this.achievements = data.achievements ? data.achievements.map((achievement: any) => new UserAchievement(achievement)) : [];
 	}
 }


### PR DESCRIPTION
Hey there!

I came across an edge case where I got back a successful response but no achievements found.

The request

```sh
curl -H 'accept: */*' --compressed -H 'user-agent: SteamAPI/3.0.12 (https://www.npmjs.com/package/steamapi)' -H 'Connection: keep-alive' 'https://api.steampowered.com/ISteamUserStats/GetPlayerAchievements/v1?steamid=REDACTED&appid=399780&l=english&key=REDACTED'
```

The response

```json
{
    "playerstats": {
        "gameName": "Expand",
        "steamID": "REDACTED",
        "success": true
    }
}
```

Please let me know if there is anything else missing or mishandled but this would solve an edge case some others may face.

thanks!