### PR TITLE
fix (#61): Ensure default values for games and servers in API responses

### DIFF
--- a/src/SteamAPI.ts
+++ b/src/SteamAPI.ts
@@ -585,6 +585,8 @@ export default class SteamAPI {
 
 		const json = await this.get('/IPlayerService/GetRecentlyPlayedGames/v1', { steamid: id, count });
 
+		json.response.games = json.response.games || [];
+
 		return json.response.games.map((data: any) => new UserPlaytime(data, new GameInfoBasic(data)));
 	}
 

--- a/src/structures/UserServers.ts
+++ b/src/structures/UserServers.ts
@@ -18,6 +18,9 @@ export default class UserServers {
 	lastActionTimestamp: number;
 
 	constructor(data: any) {
+
+		data.servers = data.server || [];
+
 		this.servers = data.servers.map((server: any) => new UserServer(server));
 		this.banned = data.is_banned;
 		this.expiresTimestamp = data.expires;


### PR DESCRIPTION
Fixed edge cases where the steam user has not played any recent games causing the api response object in `getUserRecentGames`  to not have games property.

Additionally fixed similar edge case where steam user does not have any user servers in api response object in `getUserServers`. 

[#61](https://github.com/xDimGG/node-steamapi/issues/61)