### PR TITLE
Add strongly typed response for getGameDetails with array caching

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import { Country, State, City } from './src/structures/Locations.js';
 import NewsPost from './src/structures/NewsPost.js';
 import Server, { ServerRegion } from './src/structures/Server.js';
 import Game from './src/structures/Game.js';
+import GameDetails from './src/structures/GameDetails.js';
 import GameInfo from './src/structures/GameInfo.js';
 import GameInfoExtended from './src/structures/GameInfoExtended.js';
 import GameInfoBasic from './src/structures/GameInfoBasic.js';
@@ -55,6 +56,7 @@ export {
 	State,
 	City,
 	Game,
+	GameDetails,
 	GameInfo,
 	GameInfoExtended,
 	GameInfoBasic,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "steamapi",
-	"version": "3.0.9",
+	"version": "3.0.12",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "steamapi",
-			"version": "3.0.9",
+			"version": "3.0.12",
 			"license": "MIT",
 			"dependencies": {
 				"node-fetch": "^3.3.2",
@@ -15,9 +15,60 @@
 			"devDependencies": {
 				"@types/node": "^20.11.5",
 				"@types/steamid": "^2.0.3",
-				"typedoc": "^0.25.7",
-				"typedoc-plugin-markdown": "^3.17.1",
-				"typescript": "^5.3.3"
+				"typedoc": "^0.27.7",
+				"typedoc-plugin-markdown": "^4.4.2",
+				"typescript": "^5.7.3"
+			}
+		},
+		"node_modules/@gerrit0/mini-shiki": {
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
+			"integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/engine-oniguruma": "^1.27.2",
+				"@shikijs/types": "^1.27.2",
+				"@shikijs/vscode-textmate": "^10.0.1"
+			}
+		},
+		"node_modules/@shikijs/engine-oniguruma": {
+			"version": "1.29.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
+			"integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/types": "1.29.2",
+				"@shikijs/vscode-textmate": "^10.0.1"
+			}
+		},
+		"node_modules/@shikijs/types": {
+			"version": "1.29.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
+			"integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@shikijs/vscode-textmate": "^10.0.1",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"node_modules/@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "*"
 			}
 		},
 		"node_modules/@types/node": {
@@ -35,23 +86,33 @@
 			"integrity": "sha512-ozNMQViUYLU+NBN4v7X0bV1O8uTL1bA+WvfHtt9IKcydS4tyYKH7w1vq+xcPGWGL0PRhGtY7C1Zhaeyj2IsETw==",
 			"dev": true
 		},
-		"node_modules/ansi-sequence-parser": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
-			"dev": true
+		"node_modules/@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"license": "Python-2.0"
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -62,6 +123,19 @@
 			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/fetch-blob": {
@@ -97,32 +171,15 @@
 				"node": ">=12.20.0"
 			}
 		},
-		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.2",
-				"source-map": "^0.6.1",
-				"wordwrap": "^1.0.0"
-			},
-			"bin": {
-				"handlebars": "bin/handlebars"
-			},
-			"engines": {
-				"node": ">=0.4.7"
-			},
-			"optionalDependencies": {
-				"uglify-js": "^3.1.4"
+				"uc.micro": "^2.0.0"
 			}
-		},
-		"node_modules/jsonc-parser": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-			"dev": true
 		},
 		"node_modules/lunr": {
 			"version": "2.3.9",
@@ -130,23 +187,37 @@
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
 		},
-		"node_modules/marked": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+		"node_modules/markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
 			"dev": true,
-			"bin": {
-				"marked": "bin/marked.js"
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
 			},
-			"engines": {
-				"node": ">= 12"
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
 			}
 		},
-		"node_modules/minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -156,21 +227,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
 		},
 		"node_modules/node-domexception": {
 			"version": "1.0.0",
@@ -207,25 +263,14 @@
 				"url": "https://opencollective.com/node-fetch"
 			}
 		},
-		"node_modules/shiki": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"dev": true,
-			"dependencies": {
-				"ansi-sequence-parser": "^1.1.0",
-				"jsonc-parser": "^3.2.0",
-				"vscode-oniguruma": "^1.7.0",
-				"vscode-textmate": "^8.0.0"
-			}
-		},
-		"node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/steamid": {
@@ -237,43 +282,47 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.25.7",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.7.tgz",
-			"integrity": "sha512-m6A6JjQRg39p2ZVRIN3NKXgrN8vzlHhOS+r9ymUYtcUP/TIQPvWSq7YgE5ZjASfv5Vd5BW5xrir6Gm2XNNcOow==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.7.tgz",
+			"integrity": "sha512-K/JaUPX18+61W3VXek1cWC5gwmuLvYTOXJzBvD9W7jFvbPnefRnCHQCEPw7MSNrP/Hj7JJrhZtDDLKdcYm6ucg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
+				"@gerrit0/mini-shiki": "^1.24.0",
 				"lunr": "^2.3.9",
-				"marked": "^4.3.0",
-				"minimatch": "^9.0.3",
-				"shiki": "^0.14.7"
+				"markdown-it": "^14.1.0",
+				"minimatch": "^9.0.5",
+				"yaml": "^2.6.1"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
 			},
 			"engines": {
-				"node": ">= 16"
+				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x"
+				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
 			}
 		},
 		"node_modules/typedoc-plugin-markdown": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz",
-			"integrity": "sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.4.2.tgz",
+			"integrity": "sha512-kJVkU2Wd+AXQpyL6DlYXXRrfNrHrEIUgiABWH8Z+2Lz5Sq6an4dQ/hfvP75bbokjNDUskOdFlEEm/0fSVyC7eg==",
 			"dev": true,
-			"dependencies": {
-				"handlebars": "^4.7.7"
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"typedoc": ">=0.24.0"
+				"typedoc": "0.27.x"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -282,35 +331,17 @@
 				"node": ">=14.17"
 			}
 		},
-		"node_modules/uglify-js": {
-			"version": "3.17.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
 			"dev": true,
-			"optional": true,
-			"bin": {
-				"uglifyjs": "bin/uglifyjs"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			}
+			"license": "MIT"
 		},
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
-		},
-		"node_modules/vscode-oniguruma": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-			"dev": true
-		},
-		"node_modules/vscode-textmate": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
 			"dev": true
 		},
 		"node_modules/web-streams-polyfill": {
@@ -321,14 +352,67 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-			"dev": true
+		"node_modules/yaml": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
 		}
 	},
 	"dependencies": {
+		"@gerrit0/mini-shiki": {
+			"version": "1.27.2",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
+			"integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
+			"dev": true,
+			"requires": {
+				"@shikijs/engine-oniguruma": "^1.27.2",
+				"@shikijs/types": "^1.27.2",
+				"@shikijs/vscode-textmate": "^10.0.1"
+			}
+		},
+		"@shikijs/engine-oniguruma": {
+			"version": "1.29.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
+			"integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+			"dev": true,
+			"requires": {
+				"@shikijs/types": "1.29.2",
+				"@shikijs/vscode-textmate": "^10.0.1"
+			}
+		},
+		"@shikijs/types": {
+			"version": "1.29.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
+			"integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+			"dev": true,
+			"requires": {
+				"@shikijs/vscode-textmate": "^10.0.1",
+				"@types/hast": "^3.0.4"
+			}
+		},
+		"@shikijs/vscode-textmate": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+			"dev": true
+		},
+		"@types/hast": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+			"integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+			"dev": true,
+			"requires": {
+				"@types/unist": "*"
+			}
+		},
 		"@types/node": {
 			"version": "20.11.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
@@ -344,10 +428,16 @@
 			"integrity": "sha512-ozNMQViUYLU+NBN4v7X0bV1O8uTL1bA+WvfHtt9IKcydS4tyYKH7w1vq+xcPGWGL0PRhGtY7C1Zhaeyj2IsETw==",
 			"dev": true
 		},
-		"ansi-sequence-parser": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz",
-			"integrity": "sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==",
+		"@types/unist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+			"integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+			"dev": true
+		},
+		"argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -370,6 +460,12 @@
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
 			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
 		},
+		"entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true
+		},
 		"fetch-blob": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -387,24 +483,14 @@
 				"fetch-blob": "^3.1.2"
 			}
 		},
-		"handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+		"linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.2",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4",
-				"wordwrap": "^1.0.0"
+				"uc.micro": "^2.0.0"
 			}
-		},
-		"jsonc-parser": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-			"dev": true
 		},
 		"lunr": {
 			"version": "2.3.9",
@@ -412,32 +498,34 @@
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
 		},
-		"marked": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+		"markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"dev": true,
+			"requires": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			}
+		},
+		"mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
 			"dev": true
 		},
 		"minimatch": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
 			"requires": {
 				"brace-expansion": "^2.0.1"
 			}
-		},
-		"minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true
-		},
-		"neo-async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
 		},
 		"node-domexception": {
 			"version": "1.0.0",
@@ -454,22 +542,10 @@
 				"formdata-polyfill": "^4.0.10"
 			}
 		},
-		"shiki": {
-			"version": "0.14.7",
-			"resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
-			"integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
-			"dev": true,
-			"requires": {
-				"ansi-sequence-parser": "^1.1.0",
-				"jsonc-parser": "^3.2.0",
-				"vscode-oniguruma": "^1.7.0",
-				"vscode-textmate": "^8.0.0"
-			}
-		},
-		"source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+		"punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"dev": true
 		},
 		"steamid": {
@@ -478,38 +554,36 @@
 			"integrity": "sha512-+BFJMbo+IxzyfovLR37E7APkaNfmrL3S+88T7wTMRHnQ6LBhzEawPnjfWNKM9eUL/dH45j+7vhSX4WaGXoa4/Q=="
 		},
 		"typedoc": {
-			"version": "0.25.7",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.7.tgz",
-			"integrity": "sha512-m6A6JjQRg39p2ZVRIN3NKXgrN8vzlHhOS+r9ymUYtcUP/TIQPvWSq7YgE5ZjASfv5Vd5BW5xrir6Gm2XNNcOow==",
+			"version": "0.27.7",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.7.tgz",
+			"integrity": "sha512-K/JaUPX18+61W3VXek1cWC5gwmuLvYTOXJzBvD9W7jFvbPnefRnCHQCEPw7MSNrP/Hj7JJrhZtDDLKdcYm6ucg==",
 			"dev": true,
 			"requires": {
+				"@gerrit0/mini-shiki": "^1.24.0",
 				"lunr": "^2.3.9",
-				"marked": "^4.3.0",
-				"minimatch": "^9.0.3",
-				"shiki": "^0.14.7"
+				"markdown-it": "^14.1.0",
+				"minimatch": "^9.0.5",
+				"yaml": "^2.6.1"
 			}
 		},
 		"typedoc-plugin-markdown": {
-			"version": "3.17.1",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.17.1.tgz",
-			"integrity": "sha512-QzdU3fj0Kzw2XSdoL15ExLASt2WPqD7FbLeaqwT70+XjKyTshBnUlQA5nNREO1C2P8Uen0CDjsBLMsCQ+zd0lw==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.4.2.tgz",
+			"integrity": "sha512-kJVkU2Wd+AXQpyL6DlYXXRrfNrHrEIUgiABWH8Z+2Lz5Sq6an4dQ/hfvP75bbokjNDUskOdFlEEm/0fSVyC7eg==",
 			"dev": true,
-			"requires": {
-				"handlebars": "^4.7.7"
-			}
+			"requires": {}
 		},
 		"typescript": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
 			"dev": true
 		},
-		"uglify-js": {
-			"version": "3.17.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-			"dev": true,
-			"optional": true
+		"uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true
 		},
 		"undici-types": {
 			"version": "5.26.5",
@@ -517,27 +591,15 @@
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
 			"dev": true
 		},
-		"vscode-oniguruma": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
-			"integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-			"dev": true
-		},
-		"vscode-textmate": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
-			"integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
-			"dev": true
-		},
 		"web-streams-polyfill": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
 			"integrity": "sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ=="
 		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+		"yaml": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
 	"devDependencies": {
 		"@types/node": "^20.11.5",
 		"@types/steamid": "^2.0.3",
-		"typedoc": "^0.25.7",
-		"typedoc-plugin-markdown": "^3.17.1",
-		"typescript": "^5.3.3"
+		"typedoc": "^0.27.7",
+		"typedoc-plugin-markdown": "^4.4.2",
+		"typescript": "^5.7.3"
 	},
 	"dependencies": {
 		"node-fetch": "^3.3.2",

--- a/src/SteamAPI.ts
+++ b/src/SteamAPI.ts
@@ -342,7 +342,7 @@ export default class SteamAPI {
 		const isArr = Array.isArray(app);
 		const appIds = isArr ? app : [app];
 
-		const cached = appIds.map(a => this.gameDetailCache?.get(`${a}-${currency}-${language}`)).filter(d => d !== undefined);
+		const cached = appIds.map(a => this.gameDetailCache?.get(`${a}-${currency}-${language}`)).filter(g => g !== undefined);
 		const remainingAppIds = appIds.filter((_, i) => cached[i] === undefined);
 
 		// If some appIds were missing from the cache, fetch from Steam and update the cache
@@ -357,7 +357,7 @@ export default class SteamAPI {
 				.then(json => {
 					if (json === null) throw new Error('Failed to find app ID');
 
-					const filtered: { [key: string]: GameDetails } = {};
+					const filtered: { [key: string]: any } = {};
 					for (const [k, v] of Object.entries(json))
 						if ((v as any).success) {
 							const d = (v as any).data;
@@ -371,7 +371,8 @@ export default class SteamAPI {
 				});
 
 			for (const appId in details) {
-				this.gameDetailCache?.set(`${appId}-${currency}-${language}`, details[appId]);
+				const game = new GameDetails(details[appId]);
+				this.gameDetailCache?.set(`${appId}-${currency}-${language}`, game);
 				cached.push(details[appId]);
 			}
 		}

--- a/src/SteamAPI.ts
+++ b/src/SteamAPI.ts
@@ -15,6 +15,7 @@ import UserStats from './structures/UserStats.js';
 import NewsPost from './structures/NewsPost.js';
 import Server from './structures/Server.js';
 import Game from './structures/Game.js';
+import GameDetails from './structures/GameDetails.js';
 import GameInfo from './structures/GameInfo.js';
 import GameInfoExtended from './structures/GameInfoExtended.js';
 import GameInfoBasic from './structures/GameInfoBasic.js';
@@ -180,7 +181,7 @@ export default class SteamAPI {
 	baseStore;
 	baseActions;
 
-	gameDetailCache?: CacheMap<string, Object>;
+	gameDetailCache?: CacheMap<string, GameDetails>;
 	userResolveCache?: CacheMap<string, string>;
 
 	private key = '';
@@ -203,7 +204,7 @@ export default class SteamAPI {
 			}
 		}
 
-		options = {...defaultOptions, ...options};
+		options = { ...defaultOptions, ...options };
 
 		if (options.inMemoryCacheEnabled) {
 			if (options.gameDetailCacheEnabled && options.gameDetailCacheTTL)
@@ -335,46 +336,51 @@ export default class SteamAPI {
 	async getGameDetails(
 		app: number | number[],
 		{ language = this.language, currency = this.currency, filters = [] } = {}
-	): Promise<{ [key: string]: any }> {
+	): Promise<GameDetails | { [key: number]: GameDetails } | undefined> {
 		assertApp(app);
 
 		const isArr = Array.isArray(app);
-		const key = `${app}-${currency}-${language}`;
+		const appIds = isArr ? app : [app];
 
-		// For now we're not touching the cache if an array of apps is passed
-		// TODO: maybe cache apps individually if an array is passed?
-		if (!isArr) {
-			const cached = this.gameDetailCache?.get(key);
-			if (cached) return cached;
+		const cached = appIds.map(a => this.gameDetailCache?.get(`${a}-${currency}-${language}`)).filter(d => d !== undefined);
+		const remainingAppIds = appIds.filter((_, i) => cached[i] === undefined);
+
+		// If some appIds were missing from the cache, fetch from Steam and update the cache
+		if (remainingAppIds.length !== 0) {
+			const details = await this
+				.get('/appdetails', {
+					appids: remainingAppIds.join(','),
+					cc: currency,
+					l: language,
+					filters: isArr && appIds.length > 1 ? 'price_overview' : filters.join(','),
+				}, this.baseStore)
+				.then(json => {
+					if (json === null) throw new Error('Failed to find app ID');
+
+					const filtered: { [key: string]: GameDetails } = {};
+					for (const [k, v] of Object.entries(json))
+						if ((v as any).success) {
+							const d = (v as any).data;
+							// Convert empty arrays to empty objects for consistency
+							filtered[k] = Array.isArray(d) && d.length === 0 ? {} : d;
+						}
+
+					if (Object.keys(filtered).length === 0) throw new Error('Failed to find app ID');
+
+					return filtered;
+				});
+
+			for (const appId in details) {
+				this.gameDetailCache?.set(`${appId}-${currency}-${language}`, details[appId]);
+				cached.push(details[appId]);
+			}
 		}
 
-		const details = await this
-			.get('/appdetails', {
-				appids: isArr ? app.join(',') : app,
-				cc: currency,
-				l: language,
-				filters: isArr && app.length > 1 ? 'price_overview' : filters.join(','),
-			}, this.baseStore)
-			.then(json => {
-				if (json === null) throw new Error('Failed to find app ID');
+		if (!isArr) return cached[0];
 
-				// TODO: make a class
-				const filtered: { [key: string]: any } = {};
-				for (const [k, v] of Object.entries(json))
-					if ((v as any).success) {
-						const d = (v as any).data;
-						// Convert empty arrays to empty objects for consistency
-						filtered[k] = Array.isArray(d) && d.length === 0 ? {} : d;
-					}
-
-				if (Object.keys(filtered).length === 0) throw new Error('Failed to find app ID');
-
-				return isArr ? filtered : filtered[app];
-			});
-
-		if (!isArr) this.gameDetailCache?.set(key, details);
-
-		return details;
+		const cachedObject: { [key: number]: GameDetails } = {};
+		for (const details of cached) cachedObject[details.id] = details;
+		return cachedObject;
 	}
 
 	/**
@@ -498,7 +504,7 @@ export default class SteamAPI {
 		for (const [k, v] of Object.entries(params))
 			if (v === undefined)
 				delete params[k];
-		
+
 		return (await this.get('/ISteamNews/GetNewsForApp/v2', params)).appnews.newsitems.map((item: any) => new NewsPost(item));
 	}
 

--- a/src/structures/GameDetails.ts
+++ b/src/structures/GameDetails.ts
@@ -1,0 +1,203 @@
+export default class GameDetails {
+  /** Type of app. Usually "game" */
+  type: string;
+
+  /** Display name of the app */
+  name: string;
+
+  /** App ID for this game */
+  id: number;
+
+  /** Age restriction for purchasing */
+  requiredAge: number;
+
+  /** If this game is free */
+  isFree: boolean;
+
+  /**
+   * Enum indicating level of support. E.G. "full"
+   * NOTE: I'm not sure what the possible values are
+  */
+  controllerSupport: string;
+
+  /** List of DLC app IDs for this game */
+  dlc: number[];
+
+  /**
+   * Detailed HTML from main body of the store page
+   * NOTE: This appears to be the same as aboutTheGame
+  */
+  detailedDescription: string;
+
+  /**
+   * Detailed HTML from main body of the store page
+   * NOTE: This appears to be the same as detailedDescription
+  */
+  aboutTheGame: string;
+
+  /** Short description of the game under the game banner on the store page */
+  shortDescription: string;
+
+  /** Supported languages in game */
+  supportedLanguages: string;
+
+  /** URL to the header image */
+  headerImage: string;
+
+  /** URL to the capsule image 231x87px */
+  capsuleImage: string;
+
+  /** URL to the capsule image 184x69px */
+  capsuleImagev5: string;
+
+  /** URL to the game's website */
+  website: string;
+
+  /** HTML specs for minimum and recommended PC hardware */
+  pcRequirements: { minimum: string; recommended: string };
+
+  /** HTML specs for minimum and recommended Mac hardware */
+  macRequirements: { minimum: string; recommended: string };
+
+  /** HTML specs for minimum and recommended Linux hardware */
+  linuxRequirements: { minimum: string; recommended: string };
+
+  /** Legal notice for the game */
+  legalNotice: string;
+
+  /** Array of developer names */
+  developers: string[];
+
+  /** Array of publisher names */
+  publishers: string[];
+
+  /** Price overview including discounts. Calculated in the given currency when requesting app details */
+  priceOverview: {
+    currency: string;
+    initial: number;
+    final: number;
+    discountPercent: number;
+    initialFormatted: string;
+    finalFormatted: string;
+  };
+
+  /** Array of IDs for the purchasing options of the game */
+  packages: number[];
+
+  /** Array of package groups containing purchase details for each package */
+  packageGroups: {
+    name: string;
+    title: string;
+    description: string;
+    selectionText: string;
+    saveText: string;
+    displayType: number;
+    isRecurringSubscription: string;
+    subs: {
+      packageid: number;
+      percentSavingsText: string;
+      percentSavings: number;
+      optionText: string;
+      optionDescription: string;
+      canGetFreeLicense: string;
+      isFreeLicense: boolean;
+      priceInCentsWithDiscount: number;
+    }[];
+  }[];
+
+  /** Supported platforms */
+  platforms: { windows: boolean; mac: boolean; linux: boolean; };
+
+  /** Metacritic score and website URL */
+  metacritic: { score: number; url: string; };
+
+  /** Array of Steam categories with IDs and short descriptions */
+  categories: { id: number; description: string }[];
+
+  /**
+   * Array of Steam genres with IDs and short descriptions
+   * NOTE: ID is a string for genres rather than a number like most other ID in Steam
+  */
+  genres: { id: string; description: string }[];
+
+  /** Array of screenshot thumbnail and full path URLs */
+  screenshots: { id: number; path_thumbnail: string; path_full: string }[];
+
+  /** Array of movie information including thumbnail and video URLs */
+  movies: {
+    id: number;
+    name: string;
+    thumbnail: string;
+    webm: { '480': string; max: string };
+    mp4: { '480': string; max: string };
+    highlight: boolean;
+  }[];
+
+  /** Number of positive reviews */
+  recommendations: { total: number };
+
+  /** Number of achievements and array of achievements from the right column of the store page */
+  achievements: { total: number; highlighted: { name: string; path: string }[] };
+
+  /** Release date information */
+  releaseDate: { coming_soon: boolean; date: string };
+
+  /** Support information including URL and email */
+  supportInfo: { url: string; email: string };
+
+  /** Background image URL scaled for store page */
+  background: string;
+
+  /** Raw background image URL */
+  backgroundRaw: string;
+
+  /** Unsure what this is. It has always been an empty array of ids and null notes for games tested */
+  contentDescriptors: { ids: number[]; notes: string | null };
+
+  /**
+   * Ratings for different rating systems
+   * NOTE: These appear to have a different object structure based on the game
+  */
+  ratings: any;
+
+  constructor(data: any) {
+    this.type = data.type;
+    this.name = data.name;
+    this.id = data.steam_appid;
+    this.requiredAge = data.required_age;
+    this.isFree = data.is_free;
+    this.controllerSupport = data.controller_support;
+    this.dlc = data.dlc;
+    this.detailedDescription = data.detailed_description;
+    this.aboutTheGame = data.about_the_game;
+    this.shortDescription = data.short_description;
+    this.supportedLanguages = data.supported_languages;
+    this.headerImage = data.header_image;
+    this.capsuleImage = data.capsule_image;
+    this.capsuleImagev5 = data.capsule_image;
+    this.website = data.website;
+    this.pcRequirements = data.pc_requirements;
+    this.macRequirements = data.mac_requirements;
+    this.linuxRequirements = data.linux_requirements;
+    this.legalNotice = data.legal_notice;
+    this.developers = data.developers;
+    this.publishers = data.publishers;
+    this.priceOverview = data.price_overview;
+    this.packages = data.packages;
+    this.packageGroups = data.package_groups;
+    this.platforms = data.platforms;
+    this.metacritic = data.metacritic;
+    this.categories = data.categories;
+    this.genres = data.genres;
+    this.screenshots = data.screenshots;
+    this.movies = data.movies;
+    this.recommendations = data.recommendations;
+    this.achievements = data.achievements;
+    this.releaseDate = data.release_date;
+    this.supportInfo = data.support_info;
+    this.background = data.background;
+    this.backgroundRaw = data.background_raw;
+    this.contentDescriptors = data.content_descriptors;
+    this.ratings = data.ratings;
+  }
+}


### PR DESCRIPTION
I have been using `node-steamapi` recently for a project and primarily use the `getGameDetails` method for product details on Steam. I've created a typed class here based on the results I've seen looking through various apps. There's probably some missing nuance for some types as I've noticed inconsistency in some responses from Steam's API and noted them already in the docs.

I have also implemented caching for arrays of app IDs given. `getGameDetails` will fetch all app IDs from the cache first, check if it needs to look up any remaining details from Steam, and if so add them to the cache individually.

The Typescript and Typedoc version bumps are to fix an error with Typescript checking array values and incorrectly thinking undefined assignments were happening. Unfortunately, the only compatible versions with one another are basically the latest versions. Typedoc 4.0.0+ went through a major UI overhaul, and generating the new documentation rewrites the entire docs folder. If you would rather not upgrade, I can try to work around the undefined issues I was seeing with Typescript and remove the version upgrades.