### PR TITLE
fix: correct expire check by using the expected operator

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -19,7 +19,7 @@ export class MemoryCacheMap<K, V> implements CacheMap<K, V> {
 
 	get(key: K): V | undefined {
 		const val = this.map.get(key);
-		if (val && val.expiresAt >= Date.now()) {
+		if (val && val.expiresAt <= Date.now()) {
 			this.map.delete(key);
 			return;
 		}


### PR DESCRIPTION
`MemoryCacheMap.get()` currently uses the opposite operator. This means that the cache is almost never hit, and if it is ever hit, it will forever contain stale data until the instance of `MemoryCacheMap` is destroyed.