### PR TITLE
fix: use native fetch when available, fallback to node-fetch

### DIFF
--- a/src/fetch-impl.ts
+++ b/src/fetch-impl.ts
@@ -1,0 +1,2 @@
+// Uses global fetch if available, otherwise uses node-fetch, allows for support for modern node and serverless environmentsexport 
+export const fetchImpl = typeof fetch !== "undefined" ? fetch : (await import("node-fetch")).default;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import nodeFetch from 'node-fetch';
+// Use custom fetch implementation
+import { fetchImpl } from "./fetch-impl.js";
 
 const reg = /<h1>(.*)<\/h1>/;
 
@@ -10,7 +11,7 @@ const reg = /<h1>(.*)<\/h1>/;
  */
 export async function fetch(url: string, options: any): Promise<any> {
 	// console.log(url);
-	const res = await nodeFetch(url, options);
+	const res = await fetchImpl(url, options);
 	if (res.status === 400) {
 		const data = await res.text();
 		throw new Error(data.match(reg)?.[1] || data);


### PR DESCRIPTION
This change replaces the hard `node-fetch` import with a conditional fallback to native `fetch`, improving compatibility with environments like Cloudflare Workers and Node 18+.

- Native `fetch` is now used when available
- Falls back to `node-fetch` for older Node versions
- Non-breaking; original behavior remains intact

Tested locally using Node 23.11.0.