### PR TITLE
fix: handle empty response in getUserOwnedGames

### DIFF
--- a/src/SteamAPI.ts
+++ b/src/SteamAPI.ts
@@ -588,7 +588,7 @@ export default class SteamAPI {
 
 
 		const json = await this.get('/IPlayerService/GetOwnedGames/v1', params);
-		return json.response.games.map((data: any) => {
+		return (json.response.games || []).map((data: any) => {
 			let game;
 			if (opts.includeExtendedAppInfo) game = new GameInfoExtended(data);
 			else if (opts.includeAppInfo) game = new GameInfo(data);


### PR DESCRIPTION
## Summary
- Fix `getUserOwnedGames()` crashing when a user has no games
- When the Steam API returns `{"response": {"game_count": 0}}` (without a `games` array), calling `.map()` on `undefined` throws an error
- Added `|| []` fallback, consistent with how `getUserRecentGames()` already handles this case (line 614)

## Test plan
- [ ] Call `getUserOwnedGames()` on a Steam account with no owned games
- [ ] Verify it returns an empty array instead of throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)