### PR TITLE
return undefined in player level if profile is undefined

### DIFF
--- a/docs/classes/default.md
+++ b/docs/classes/default.md
@@ -813,7 +813,7 @@ Group IDs
 
 ### getUserLevel()
 
-> **getUserLevel**(`id`): `Promise`\<`number`\>
+> **getUserLevel**(`id`): `Promise`\<`number` \| `undefined`\>
 
 Defined in: [SteamAPI.ts:547](https://github.com/xDimGG/node-steamapi/blob/f4d6bcd21f6389481b7da485ce2cb9bddf197216/src/SteamAPI.ts#L547)
 
@@ -829,9 +829,9 @@ User ID
 
 #### Returns
 
-`Promise`\<`number`\>
+`Promise`\<`number` \| `undefined`\>
 
-The user's Steam level
+The user's Steam level, or undefined if the profile is private
 
 ***
 

--- a/src/SteamAPI.ts
+++ b/src/SteamAPI.ts
@@ -542,9 +542,9 @@ export default class SteamAPI {
 	/**
 	 * Get a user's level
 	 * @param id User ID
-	 * @returns The user's Steam level
+	 * @returns The user's Steam level, or undefined if the profile is private
 	 */
-	async getUserLevel(id: string): Promise<number> {
+	async getUserLevel(id: string): Promise<number | undefined> {
 		assertID(id);
 
 		return (await this.get('/IPlayerService/GetSteamLevel/v1', { steamid: id })).response.player_level;


### PR DESCRIPTION
If the player has private profile, like 76561198065402027, it returns undefined, as it's an empty object